### PR TITLE
Add special checkbox and clipboard copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# veo3prompt
+# Cardiff Airport Comedy Prompt Builder
+
+This project provides a small [Streamlit](https://streamlit.io/) app for creating dialogue prompts.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   streamlit run main.py
+   ```
+
+The app lets you pick a scene and character from the included JSON files and compose a line of dialogue. Check **Use bespoke scene** to type your own setting instead of selecting from the list.
+
+Tick **Include random joke** to add a line from `one.csv`; used jokes are removed so they don't repeat. Tick **Include random life advice** to insert a line from `life.csv`.
+
+Tick **Include random special** to add a quick tip from `special.csv`.
+
+You can enter an optional character description that will be appended to the prompt and select a second character to appear in the scene.
+
+Prompts can be previewed in the browser and saved to a text or CSV file of your choice.
+After previewing, click **Copy Preview to Clipboard** to copy the text for use elsewhere.

--- a/life.csv
+++ b/life.csv
@@ -1,0 +1,6 @@
+advice
+"Never go to bed angry—stay awake and plot your revenge."
+"Keep your friends close and your receipts closer."
+"Life's too short for cheap coffee."
+"Measure twice, cut once, then measure again just to be sure."
+"Sometimes the best answer is 'I'll get back to you on that.'"

--- a/main.py
+++ b/main.py
@@ -1,11 +1,14 @@
-import streamlit as st
+import csv
 import json
-import os
+import random
 
-# Load data
-with open("characters.json", "r", encoding="utf-8") as f:
+import streamlit as st
+import streamlit.components.v1 as components
+
+# Load character and scene data
+with open("characters.json", encoding="utf-8") as f:
     characters = json.load(f)
-with open("scenes.json", "r", encoding="utf-8") as f:
+with open("scenes.json", encoding="utf-8") as f:
     scenes = json.load(f)
 
 character_names = [c["name"] for c in characters]
@@ -14,24 +17,122 @@ scene_names = [s["name"] for s in scenes]
 character_dict = {c["name"]: c["description"] for c in characters}
 scene_dict = {s["name"]: s["description"] for s in scenes}
 
+# Load jokes from CSV
+with open("one.csv", newline="", encoding="utf-8") as f:
+    reader = csv.DictReader(f)
+    jokes = [row["joke"] for row in reader if row.get("joke")]
+
+# Load life advice from CSV
+with open("life.csv", newline="", encoding="utf-8") as f:
+    reader = csv.DictReader(f)
+    advice_lines = [row["advice"] for row in reader if row.get("advice")]
+
+# Load special lines from CSV
+with open("special.csv", newline="", encoding="utf-8") as f:
+    reader = csv.DictReader(f)
+    special_lines = [row["special"] for row in reader if row.get("special")]
+
 st.title("Cardiff Airport Comedy Prompt Builder")
 
-save_file = st.text_input("Save prompts to file (e.g., prompts.txt or prompts.csv)", value="prompts.txt")
+save_file = st.text_input(
+    "Save prompts to file (e.g., prompts.txt or prompts.csv)",
+    value="prompts.txt",
+)
 
-scene = st.selectbox("Select Scene", scene_names)
+use_bespoke = st.checkbox("Use bespoke scene")
+if use_bespoke:
+    bespoke_scene = st.text_area(
+        "Bespoke Scene Description", height=80, placeholder="Enter scene"
+    )
+    scene_desc = bespoke_scene
+else:
+    scene = st.selectbox("Select Scene", scene_names)
+    scene_desc = scene_dict[scene]
+
 character = st.selectbox("Select Character", character_names)
+character2 = st.selectbox(
+    "Select Second Character (optional)", ["None"] + character_names
+)
 
-st.write("**Scene Description:**", scene_dict[scene])
+st.write("**Scene Description:**", scene_desc)
 st.write("**Character Description:**", character_dict[character])
+if character2 != "None":
+    st.write("**Second Character Description:**", character_dict[character2])
+
+include_joke = st.checkbox("Include random joke")
+include_advice = st.checkbox("Include random life advice")
+include_special = st.checkbox("Include random special")
+extra_description = st.text_input(
+    "Additional character description (optional)"
+)
 
 dialogue = st.text_area("Enter Character’s Line")
 
 if st.button("Preview Prompt"):
-    result = f"Scene: {scene_dict[scene]}\n{character}—{character_dict[character]}\n{character}: {dialogue}"
-    st.text_area("Prompt Preview", value=result, height=150)
+    result = (
+        f"Scene: {scene_desc}\n" f"{character}—{character_dict[character]}"
+    )
+    if extra_description.strip():
+        result += f" {extra_description.strip()}"
+    if character2 != "None":
+        result += f"\n{character2}—{character_dict[character2]}"
+    result += f"\n{character}: {dialogue}"
+    if include_joke and jokes:
+        st.session_state.preview_joke = random.choice(jokes)
+        result += f"\nJoke: {st.session_state.preview_joke}"
+    if include_advice and advice_lines:
+        st.session_state.preview_advice = random.choice(advice_lines)
+        result += f"\nAdvice: {st.session_state.preview_advice}"
+    if include_special and special_lines:
+        st.session_state.preview_special = random.choice(special_lines)
+        result += f"\nSpecial: {st.session_state.preview_special}"
+    st.session_state.preview_result = result
+    st.session_state.show_copy = True
+    st.text_area("Prompt Preview", value=result, height=200)
+
+if st.session_state.get("show_copy"):
+    if st.button("Copy Preview to Clipboard"):
+        text = st.session_state.preview_result.replace("`", "\\`")
+        components.html(
+            f"<script>navigator.clipboard.writeText(`{text}`);</script>",
+            height=0,
+        )
+        st.success("Prompt copied to clipboard")
 
 if st.button("Save Prompt"):
-    result = f"Scene: {scene_dict[scene]}\n{character}—{character_dict[character]}\n{character}: {dialogue}\n---\n"
+    result = (
+        f"Scene: {scene_desc}\n" f"{character}—{character_dict[character]}"
+    )
+    if extra_description.strip():
+        result += f" {extra_description.strip()}"
+    if character2 != "None":
+        result += f"\n{character2}—{character_dict[character2]}"
+    result += f"\n{character}: {dialogue}"
+    joke_to_use = None
+    if include_joke and jokes:
+        joke_to_use = st.session_state.get("preview_joke") or random.choice(
+            jokes
+        )
+        result += f"\nJoke: {joke_to_use}"
+        if joke_to_use in jokes:
+            jokes.remove(joke_to_use)
+            with open("one.csv", "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=["joke"])
+                writer.writeheader()
+                for j in jokes:
+                    writer.writerow({"joke": j})
+        st.session_state.preview_joke = ""
+    if include_advice and advice_lines:
+        advice_to_use = st.session_state.get(
+            "preview_advice"
+        ) or random.choice(advice_lines)
+        result += f"\nAdvice: {advice_to_use}"
+    if include_special and special_lines:
+        special_to_use = st.session_state.get(
+            "preview_special"
+        ) or random.choice(special_lines)
+        result += f"\nSpecial: {special_to_use}"
+    result += "\n---\n"
     with open(save_file, "a", encoding="utf-8") as f:
         f.write(result)
     st.success(f"Prompt saved to {save_file}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/special.csv
+++ b/special.csv
@@ -1,0 +1,6 @@
+special
+"Wear mismatched socks for good luck."
+"Eat dessert first in case you get full."
+"Carry duct tape everywhere."
+"Smile at strangers—it's free."
+"Always keep a spare biscuit in your pocket."


### PR DESCRIPTION
## Summary
- add ability to copy the preview text to the clipboard
- support `special.csv` lines via new checkbox
- document new features

## Testing
- `black main.py --line-length 79`
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_687fbe447e4483278ac444d207d1f90c